### PR TITLE
Upgrade to alpine:3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM	alpine:3.9
+FROM	alpine:3.11
 
 LABEL	org.label-schema.description="Useful network related tools"
 LABEL	org.label-schema.vendor=travelping.com
 LABEL	org.label-schema.copyright=travelping.com
-LABEL	org.label-schema.version=1.10.0
+LABEL	org.label-schema.version=1.10.1
 
 RUN		apk add --no-cache --update \
 		bash \


### PR DESCRIPTION
The following software is upgraded as a result of the change of the base
OS:

* bash: 4.4.19 -> 5.0.11
* busybox: 1.29.3 -> busybox-1.31.1
* ca-certificates: 20190108 -> 20191127
* conntrack-tools: 1.4.4 -> 1.4.5
* coreutils: 8.30 -> 8.31
* curl: 7.64.0 -> 7.67.0
* drill: 1.7.0 -> 1.7.1
* ethtool: 4.19 -> 5.3
* ip6tables: 1.6.2 -> 1.8.3
* iperf3: 3.6 -> 3.7
* iproute2: 4.19 -> 5.4
* iptables: 1.6.2 -> 1.8.3
* iputils: 20180629 -> 20190709
* keepalived: 2.0.11 -> 2.0.19
* mtr: 0.92 -> 0.93
* nftables: 0.9.0 -> 0.9.3
* socat: 1.7.3.2 -> 1.7.3.3
* tcpdump: 4.9.2 -> 4.9.3