### PR TITLE
Add netsniff-ng, trafgen and bpfc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apk add --no-cache --update \
         bison
 
 RUN git clone git://github.com/netsniff-ng/netsniff-ng.git
-RUN cd netsniff-ng
 
 WORKDIR /workspace/netsniff-ng
 RUN git checkout v0.6.7
@@ -24,7 +23,7 @@ FROM alpine:3.15
 LABEL org.label-schema.description="Useful network related tools"
 LABEL org.label-schema.vendor=travelping.com
 LABEL org.label-schema.copyright=travelping.com
-LABEL org.label-schema.version=1.10.1
+LABEL org.label-schema.version=1.11.0
 
 COPY --from=builder /usr/local/sbin/bpfc /usr/local/sbin/bpfc
 COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,34 @@
-FROM	alpine:3.11
+FROM alpine:3.15 as builder
+
+WORKDIR /workspace
+
+RUN	apk add --no-cache --update \
+		linux-headers \
+		alpine-sdk \
+		coreutils \
+		bash \
+		git \
+		flex \
+		bison
+
+RUN git clone git://github.com/netsniff-ng/netsniff-ng.git
+RUN cd netsniff-ng
+
+WORKDIR /workspace/netsniff-ng
+RUN git checkout v0.6.7
+
+RUN ./configure && make && mkdir /usr/local/sbin && make install
+
+FROM	alpine:3.15
 
 LABEL	org.label-schema.description="Useful network related tools"
 LABEL	org.label-schema.vendor=travelping.com
 LABEL	org.label-schema.copyright=travelping.com
 LABEL	org.label-schema.version=1.10.1
+
+COPY --from=builder /usr/local/sbin/bpfc /usr/local/sbin/bpfc
+COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng
+COPY --from=builder /usr/local/sbin/trafgen /usr/local/sbin/trafgen
 
 RUN		apk add --no-cache --update \
 		bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM alpine:3.15 as builder
 
 WORKDIR /workspace
 
-RUN	apk add --no-cache --update \
-		linux-headers \
-		alpine-sdk \
-		coreutils \
-		bash \
-		git \
-		flex \
-		bison
+RUN apk add --no-cache --update \
+        linux-headers \
+        alpine-sdk \
+        coreutils \
+        bash \
+        git \
+        flex \
+        bison
 
 RUN git clone git://github.com/netsniff-ng/netsniff-ng.git
 RUN cd netsniff-ng
@@ -19,33 +19,33 @@ RUN git checkout v0.6.7
 
 RUN ./configure && make && mkdir /usr/local/sbin && make install
 
-FROM	alpine:3.15
+FROM alpine:3.15
 
-LABEL	org.label-schema.description="Useful network related tools"
-LABEL	org.label-schema.vendor=travelping.com
-LABEL	org.label-schema.copyright=travelping.com
-LABEL	org.label-schema.version=1.10.1
+LABEL org.label-schema.description="Useful network related tools"
+LABEL org.label-schema.vendor=travelping.com
+LABEL org.label-schema.copyright=travelping.com
+LABEL org.label-schema.version=1.10.1
 
 COPY --from=builder /usr/local/sbin/bpfc /usr/local/sbin/bpfc
 COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng
 COPY --from=builder /usr/local/sbin/trafgen /usr/local/sbin/trafgen
 
-RUN		apk add --no-cache --update \
-		bash \
-		conntrack-tools \
-		coreutils \
-		curl \
-		drill \
-		iperf3 \
-		iproute2 \
-		iptables \
-		iputils \
-		ip6tables \
-		keepalived \
-		net-tools \
-		nftables \
-		socat \
-		ethtool \
-		mtr \
-		tcpdump \
-		busybox-extras
+RUN apk add --no-cache --update \
+        bash \
+        conntrack-tools \
+        coreutils \
+        curl \
+        drill \
+        iperf3 \
+        iproute2 \
+        iptables \
+        iputils \
+        ip6tables \
+        keepalived \
+        net-tools \
+        nftables \
+        socat \
+        ethtool \
+        mtr \
+        tcpdump \
+        busybox-extras

--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 A simple, small, alpine-based Docker image with some handy networking tools
 installed:
 
+- bpfc
 - curl
-- iproute2
-- tcpdump
-- iperf3
 - drill
+- iperf3
+- iproute2
+- netsniff-ng
 - socat
+- tcpdump
 - telnet
+- trafgen
 
 Please see the Dockerfile for a complete list of tools.


### PR DESCRIPTION
Added `bpfc`, `netsniff-ng` and `trafgen` from https://github.com/netsniff-ng/netsniff-ng.

Also, bump to the latest alpine version