### PR TITLE
Maintenance: Upgrade base Alpinelinux image to version 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 as builder
+FROM alpine:3.22 AS builder
 
 WORKDIR /workspace
 
@@ -14,13 +14,11 @@ RUN apk add --no-cache --update \
 RUN git clone https://github.com/netsniff-ng/netsniff-ng.git
 
 WORKDIR /workspace/netsniff-ng
-RUN git checkout v0.6.8
-
+RUN git checkout v0.6.9
 RUN mkdir /etc/netsniff-ng && cp trafgen_stddef.h /etc/netsniff-ng
-
 RUN ./configure && make && mkdir /usr/local/sbin && make install
 
-FROM alpine:3.20
+FROM alpine:3.22
 
 LABEL org.label-schema.description="Useful network related tools"
 LABEL org.label-schema.vendor=travelping.com

--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@ A simple, small, alpine-based Docker image with some handy networking tools
 installed:
 
 - bpfc
-- bird2
+- bird3
 - curl
 - drill
+- ethtool
 - iperf3
 - iproute2
-- lz4
+- iptables
+- mtr
 - netsniff-ng
+- nftables
 - socat
 - tcpdump
 - telnet
 - trafgen
-- zstd
 
 Please see the Dockerfile for a complete list of tools.


### PR DESCRIPTION
Upgrade to alpine:3.22

This upgrade addresses various CVEs which piled up since the last release of **nettools**.

As part the upgrade, the following software is upgraded:

* bash:         5.2.26  -> 5.2.37
* bird:         2.15.1  -> 3.1.2
* coreutils:    9.5     -> 9.7
* curl:         8.7.1   -> 8.14.0
* drill:        1.8.3   -> 1.8.4
* ethtool:      6.7     -> 6.15
* ip6tables:    1.8.10  -> 1.8.11
* iperf3:       3.17.1  -> 3.19.0
* iproute2:     6.9     -> 6.16
* iptables:     1.8.7   -> 1.8.8
* keepalived:   2.2.8   -> 2.3.1
* netsniff-ng:  0.6.8   -> 0.6.9
* mtr:          0.94    -> 0.95
* nftables:     1.0.9   -> 1.1.3
* socat:        1.8.0.0 -> 1.8.0.3
* tcpdump:      4.99.4  -> 4.99.5