### PR TITLE
[CENNSO-1757] Add CI action to build and push nettools image to Cennso

### DIFF
--- a/.github/workflows/cennso-release.yaml
+++ b/.github/workflows/cennso-release.yaml
@@ -1,0 +1,41 @@
+name: Cennso Release of nettools
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push-to-cur:
+    name: "cur-release"
+    runs-on: [ubuntu-24.04]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.CUR_REGISTRY_URL }}
+          username: ${{ secrets.CUR_REGISTRY_USERNAME }}
+          password: ${{ secrets.CUR_REGISTRY_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.CUR_REGISTRY_URL }}/${{ secrets.CUR_PROJECT_NAME }}
+          tags: |
+            type=semver,pattern={{raw}}
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This commits adds a Github CI action to build nettools docker image and push it to the cennso registry.

For now the job should be triggered manually using the Github interface.