### PR TITLE
Add openssl to nettools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.22
 LABEL org.label-schema.description="Useful network related tools"
 LABEL org.label-schema.vendor=travelping.com
 LABEL org.label-schema.copyright=travelping.com
-LABEL org.label-schema.version=1.14.0
+LABEL org.label-schema.version=1.15.0
 
 COPY --from=builder /usr/local/sbin/bpfc /usr/local/sbin/bpfc
 COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apk add --no-cache --update \
         keepalived \
         net-tools \
         nftables \
+        openssl \
         socat \
         ethtool \
         mtr \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ installed:
 - mtr
 - netsniff-ng
 - nftables
+- openssl
 - socat
 - tcpdump
 - telnet


### PR DESCRIPTION
This PR adds OpenSSL installation to the container, which can be useful for various cryptographic operations and tools that depend on it.

In addition the version of container is bumped to 1.15.0