### PR TITLE
[CENNSO-3574] Update base Alpine image to 3.23.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22 AS builder
+FROM alpine:3.23.3 AS builder
 
 WORKDIR /workspace
 
@@ -18,12 +18,12 @@ RUN git checkout v0.6.9
 RUN mkdir /etc/netsniff-ng && cp trafgen_stddef.h /etc/netsniff-ng
 RUN ./configure && make && mkdir /usr/local/sbin && make install
 
-FROM alpine:3.22
+FROM alpine:3.23.3
 
 LABEL org.label-schema.description="Useful network related tools"
 LABEL org.label-schema.vendor=travelping.com
 LABEL org.label-schema.copyright=travelping.com
-LABEL org.label-schema.version=1.15.0
+LABEL org.label-schema.version=1.16.0
 
 COPY --from=builder /usr/local/sbin/bpfc /usr/local/sbin/bpfc
 COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng


### PR DESCRIPTION
This commit bumps the version of the base docker image to alpine 3.23.3 to include the security fixes for OpenSSL addressing the January 27, 2026 advisory.

The nettools itself is bumped to 1.16.0