### PR TITLE
[CENNSO-1757]: Feature: add tshark, dumpcap, mergecap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.23.4
 LABEL org.label-schema.description="Useful network related tools"
 LABEL org.label-schema.vendor=travelping.com
 LABEL org.label-schema.copyright=travelping.com
-LABEL org.label-schema.version=1.16.0
+LABEL org.label-schema.version=1.17.0
 
 COPY --from=builder /usr/local/sbin/bpfc /usr/local/sbin/bpfc
 COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng
@@ -31,7 +31,6 @@ COPY --from=builder /usr/local/sbin/trafgen /usr/local/sbin/trafgen
 
 RUN apk add --no-cache --update \
         bash \
-        bird \
         conntrack-tools \
         coreutils \
         curl \
@@ -49,5 +48,6 @@ RUN apk add --no-cache --update \
         ethtool \
         mtr \
         tcpdump \
+        tshark \
         busybox-extras \
         lz4 zstd

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A simple, small, alpine-based Docker image with some handy networking tools
 installed:
 
 - bpfc
-- bird3
 - curl
 - drill
 - ethtool
@@ -19,5 +18,6 @@ installed:
 - tcpdump
 - telnet
 - trafgen
+- tshark / dumpcap / mergecap
 
 Please see the Dockerfile for a complete list of tools.


### PR DESCRIPTION
The `tshark` package contains `dumpcap`. `dumpcap` has the nice property to allow multiple interfaces via the `-i` flag and the name of the picked interface will make it into the produced .pcap(ng) file. This is better than `tcpdump -i any` which loses the interface information. `mergecap` and `tshark` are just bonus features - `tshark` has nice dissector which might be handy when analysing traffic.

Also, this PR removes `bird` from the available tools: the intention of `nettools` was never to offer all kind of network-daemons. Yet, `bird` (version 2.x at the time) was introduced via e79bb7c. Via container image `vnf-bird` now both `bird:v2` as well as `bird:v3` are available. Technically, the removal of `bird` could be discussed as a breaking change - but it should have not be part of `nettools` in the first place.