### PR TITLE
[CENNSO-1757]: Feature: add `udevd`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,24 +30,26 @@ COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng
 COPY --from=builder /usr/local/sbin/trafgen /usr/local/sbin/trafgen
 
 RUN apk add --no-cache --update \
-        bash \
-        conntrack-tools \
-        coreutils \
-        curl \
-        drill \
-        iperf3 \
-        iproute2 \
-        iptables \
-        iputils \
-        ip6tables \
-        keepalived \
-        net-tools \
-        nftables \
-        openssl \
-        socat \
-        ethtool \
-        mtr \
-        tcpdump \
-        tshark \
-        busybox-extras \
-        lz4 zstd
+        bash                    \
+        busybox-extras          \
+        conntrack-tools         \
+        coreutils               \
+        curl                    \
+        drill                   \
+        ethtool                 \
+        ip6tables               \
+        iperf3                  \
+        iproute2                \
+        iptables                \
+        iputils                 \
+        keepalived              \
+        lz4                     \
+        mtr                     \
+        net-tools               \
+        nftables                \
+        openssl                 \
+        socat                   \
+        tcpdump                 \
+        tshark                  \
+        udev                    \
+        zstd

--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ installed:
 - telnet
 - trafgen
 - tshark / dumpcap / mergecap
+* udevd
 
 Please see the Dockerfile for a complete list of tools.


### PR DESCRIPTION
The `udev` package provides `udevd` - a user space demon which allows reacting on devices added to the /dev pseudo filesystem of Linux. This provides means to react on the appearance or dissapearance of a network device (such as tun/tap) within the lifecycle of the container. An (not so hypothetical) example is the creation / deletion of GRE tunnels upon establishing an IPSEC tunnel and then the need to add such GRE tunnel into an existent BRIDGE.