### PR TITLE
[CENNSO-3574] Update base Alpine image to 3.24.1

### DIFF
--- a/.github/workflows/cennso-release.yaml
+++ b/.github/workflows/cennso-release.yaml
@@ -9,18 +9,18 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ secrets.CUR_REGISTRY_DOMAIN }}
           username: ${{ secrets.CUR_REGISTRY_USERNAME }}
           password: ${{ secrets.CUR_REGISTRY_PASSWORD }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ secrets.CUR_REGISTRY_DOMAIN }}/${{ secrets.CUR_PROJECT_NAME }}
@@ -31,7 +31,7 @@ jobs:
             prefix=
             suffix=
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4 AS builder
+FROM alpine:3.24.1 AS builder
 
 WORKDIR /workspace
 
@@ -18,12 +18,12 @@ RUN git checkout v0.6.9
 RUN mkdir /etc/netsniff-ng && cp trafgen_stddef.h /etc/netsniff-ng
 RUN ./configure && make && mkdir /usr/local/sbin && make install
 
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 
 LABEL org.label-schema.description="Useful network related tools"
 LABEL org.label-schema.vendor=travelping.com
 LABEL org.label-schema.copyright=travelping.com
-LABEL org.label-schema.version=1.17.0
+LABEL org.label-schema.version=1.18.1
 
 COPY --from=builder /usr/local/sbin/bpfc /usr/local/sbin/bpfc
 COPY --from=builder /usr/local/sbin/netsniff-ng /usr/local/sbin/netsniff-ng


### PR DESCRIPTION
This PR bumps the version of the base docker image to alpine 3.24.1 

The nettools container image itself is bumped to 1.18.1